### PR TITLE
fix for XA resource enlistment ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ curl -XGET "http://tx-client-`oc project -q`.`minishift ip`.nip.io/tx-client/api
 curl -XGET "http://tx-client-`oc project -q`.`minishift ip`.nip.io/tx-client/api/ejb/stateless-programatic-pass"
 
 # stateless bean with JVM halt on the client after prepare is called on the remote ejb
-# while the remote ejb lookup is done via programatic api without outbound connection
+# the remote ejb lookup is done via programatic api without outbound connection
 curl -XGET "http://tx-client-`oc project -q`.`minishift ip`.nip.io/tx-client/api/ejb/stateless-programatic-jvm-halt-on-prepare-client"
+
+# stateless bean with JVM halt on the client before commit is called on the remote ejb
+# the remote ejb lookup is done via programatic api without outbound connection
+curl -XGET "http://tx-client-`oc project -q`.`minishift ip`.nip.io/tx-client/api/ejb/stateless-programatic-jvm-halt-on-commit-client"
 ```
 
 ## Changes in WildFly/EAP configuration
@@ -128,7 +132,7 @@ all the building. These lines could help with that
 oc delete all --all; oc delete $(oc get pvc -o name); oc delete template eap72-stateful-set
 oc create -f eap72-image-stream.json
 oc create -f eap72-stateful-set.json
-REF=tadamski-master-unchanged-my-changes
+REF=master
 REPO=ochaloup
 oc new-app --template=eap72-stateful-set -p APPLICATION_NAME=tx-client -p ARTIFACT_DIR=tx-client/target -p SOURCE_REPOSITORY_URL=https://github.com/${REPO}/openshift-tx.git -p SOURCE_REPOSITORY_REF=$REF
 oc new-app --template=eap72-stateful-set -p APPLICATION_NAME=tx-server -p ARTIFACT_DIR=tx-server/target -p SOURCE_REPOSITORY_URL=https://github.com/${REPO}/openshift-tx.git -p SOURCE_REPOSITORY_REF=$REF -p REPLICAS=2

--- a/tx-client/src/main/java/org/jboss/as/quickstarts/xa/client/PlaceToEnlist.java
+++ b/tx-client/src/main/java/org/jboss/as/quickstarts/xa/client/PlaceToEnlist.java
@@ -1,0 +1,6 @@
+package org.jboss.as.quickstarts.xa.client;
+
+public enum PlaceToEnlist {
+	BEFORE_REMOTE_EJB,
+	AFTER_REMOTE_EJB
+}

--- a/tx-common/pom.xml
+++ b/tx-common/pom.xml
@@ -34,6 +34,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-transaction-spi</artifactId>
         </dependency>


### PR DESCRIPTION
change the enlistment ordering of the test XAResource as the position of the enlistment defines how the test behaves
the transaction manager do run the XAResource handling in order thus this is important
`prepare` and `commit` tests - those ones which were intended - needs the different order for enlistment